### PR TITLE
Fix node js exe path on windows

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -625,6 +625,8 @@ def plugin_loaded():
     import stat
     os_mark = platform.system().lower()
     node_path = os.path.join(plugin_dir, "dev_bundle", os_mark, "node") # Slava: use node bundled with the plugin
+    if windows:
+      node_path += ".exe"
     if not os.access(node_path, os.X_OK):
       os.chmod(node_path, stat.S_IRWXU)
     tern_command = [node_path,  os.path.join(plugin_dir, "node_modules/tern/bin/tern"), "--no-port-file"]


### PR DESCRIPTION
append ".exe" to fix file not found error on windows
